### PR TITLE
Update ALLHiC_plot 

### DIFF
--- a/bin/ALLHiC_plot
+++ b/bin/ALLHiC_plot
@@ -61,7 +61,7 @@ def calc_read_count_per_min_size(chr_len_db, chr_order, bam, agp, min_size):
     ctg_on_chr = {}
     with open(agp, 'r') as f_in:
         for line in f_in:
-            if line.strip() == '':
+            if line.strip() == '' or line.strip().startswith('#'):
                 continue
             data = line.strip().split()
             if data[4] == 'U':


### PR DESCRIPTION
Dear Professor Zhang,

Now ALLHiC_plot can deal with .agp that have lines starts with "#".

Why I updata ALLHiC_plot:
 
When I used ALLHiC_plot with .agp proudced by juicebox_assembly_converter.py from .assembly file, the program reported ：

```
Traceback (most recent call last):
  File "ALLHiC_plot", line 250, in <module>
    ALLHiC_plot(bam, agp, chrlist, npzfile, minsize, binsize, outdir)
  File "ALLHiC_plot", line 226, in ALLHiC_plot
    bin_offset_min_size, read_count_whole_genome_min_size = calc_read_count_per_min_size(chr_len_db, chr_order, bam, agp, min_size)
  File "ALLHiC_plot", line 67, in calc_read_count_per_min_size
    if data[4] == 'U':
IndexError: list index out of range
```

Then I find the first two lines in .apg file is :

```
##agp-version 2.1
# This file was generated by converting juicebox assembly format
```

ALLHiC_plot may not think about that .agp have annotation lines.

ALLHiC is a great tools! 

Best regards

Hongkui Zhang

